### PR TITLE
1-offline-inboxing: Add MVP progress doc

### DIFF
--- a/active/1-offline-inboxing/mvp.md
+++ b/active/1-offline-inboxing/mvp.md
@@ -1,0 +1,12 @@
+# #1 - Offline Inboxing: MVP
+
+This PR can be closed once MVP for https://github.com/status-im/ideas/issues/1 is solved:
+
+```
+Minimum Viable Product
+
+Goal Date: 2017-11-24
+Description: Run a wnode from the command line; let A send message to B who is offline, and then A goes offline again. When B comes online it should call wnode which should reply with some payload that contains A's message. This payload should be visible in A-B's chat. The wnode can be hardcoded.
+```
+
+MVP Design https://app.zeplin.io/project/5863cdcee68455850f1929f2/screen/5a156473600e43d319cd1e54?


### PR DESCRIPTION
# 1 - Offline Inboxing: MVP

This PR can be closed once MVP for https://github.com/status-im/ideas/issues/1 is solved:

> Minimum Viable Product
> 
> Goal Date: 2017-11-24
> Description: Run a wnode from the command line; let A send message to B who is offline, and then A goes offline again. When B comes online it should call wnode which should reply with some payload that contains A's message. This payload should be visible in A-B's chat. The wnode can be hardcoded.

MVP now tracked here: https://github.com/orgs/status-im/projects/2