### PR TITLE
Gas Abstraction

### DIFF
--- a/ideas/073-gas-abstraction.md
+++ b/ideas/073-gas-abstraction.md
@@ -1,0 +1,78 @@
+## Preamble
+
+    Idea: 73
+    Title: Gas Abstraction
+    Status: In Progress
+    Created: 2018-02-01
+    Requires: #145
+
+## Summary
+
+Enable Status users to pay gas fee with any token that is valueable to society. 
+Users would sign a message request to contracts which will use user's balance of selected token to refund proportional used gas to a incentivezed ETH owner to include that message in a transction.p
+
+## Swarm Participants
+
+- Lead Contributor:  @3esmit
+- UX: @alexvandesande 
+- Contributor/Testing: @iurimatias 
+- Contributor/Testing: @richard-ramos 
+
+## Product Overview
+
+A barrier for user adoption to blockchain through Status would be the need of holding two tokens for paying fees, ether gas for moving the [SNT](https://etherscan.io/address/0x744d70fdbe2ba4cf95131626614a1763df805b9e#readContract) fee from user balance to decentralized service provider. 
+
+The product solve this by emulating a gas abstraction by adding "Gas Relayer Actor" in top of smart contracts as: [Identity](https://github.com/status-im/contracts/blob/73-economic-abstraction/contracts/identity/Identity.sol)[GasRelay](https://github.com/status-im/contracts/blob/73-economic-abstraction/contracts/identity/IdentityGasRelay.sol), MultiSigWallet, [SNTController](https://github.com/status-im/contracts/blob/73-economic-abstraction/contracts/status/SNTController.sol#L82) (updated from SNTPlaceHolder). 
+
+- Allows SNT holder to broadcast ethereum signed messages to anyone with ETH to validate them in the GasRelay smart contracts, and offering a refund of gas used in a gas price set in SNT. 
+- Whoever have ether could verify if the gas price worth the SNT gas price offered.
+- This becomes a micro trade of ETH->SNT.
+- Allow user to use any token they want (even ETH, or ETH stored in Identity).
+
+### Product Description
+
+Gas Relay node: Status Destkop extension or an independent node can include messages by making automatic transactions calls to smart contracts to earn tokens being offered as gas price refund.
+Fundamental pivot. 
+
+Identity Gas Relay adaptor: include terms for accepting ethereum signed messages representing authorization to call by/for Identity owner offering a gas price refund.
+Important for gas abstraction.
+
+SNT Controller Gas Relay adaptor: include terms for accepting ethereum signed messages to IdentityGasRelay facotory and for moving the tokens from there using SNT.
+Important for accounts that never held ether, just SNT.
+
+### Requirements & Dependancies
+
+Idea [#145](https://github.com/status-im/ideas/pull/145) is important to seamless and safe integration of gas abstraction for any type of call.
+Implemention of [EIP#191](https://github.com/ethereum/EIPs/issues/191) is somewhat important, specially for making signature verification slightly gas cheaper.
+
+### Minimum Viable Product
+
+Goal Date:
+Description:
+- Users can call EVM by paying gas in a selected token.
+- Users can join gas abstraction by SNTController terms
+- Users can earn tokens by including other's messages
+
+#### Identity Gas Relay
+
+Goal Date:
+Description: 
+- Gas Relay Node that recieve whisper messages from Identity owners, 
+- Identity User Interface with Gas Relayed option of calls
+
+#### SNT Gas Relayer
+
+Goal Date:
+Description: 
+- Gas Relay Node implements watching messages for SNTController 
+- User interface for creating Identity+ENS register (pay gas in SNT)
+- Moving SNT to other address from SNTController terms (paying gas in SNT)
+
+## Success Metrics
+
+Users are able to use Ethereum Virtual Machine and Status Network with only ever holding SNT.
+
+## Supporting Role Communication
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/ideas/073-gas-abstraction.md
+++ b/ideas/073-gas-abstraction.md
@@ -1,10 +1,12 @@
+# Gas Abstraction
+
 ## Preamble
 
-    Idea: 73
+    Idea: 073-gas-abstraction
     Title: Gas Abstraction
     Status: In Progress
     Created: 2018-02-01
-    Requires: #145
+    Requires: 145-identity
 
 ## Summary
 
@@ -18,7 +20,6 @@ Users would sign a message request to contracts which will use user's balance of
 - UX (Mist): @alexvandesande 
 - UX (Status): 
 - Contributor/Testing: @iurimatias 
-
 
 ## Product Overview
 
@@ -46,7 +47,7 @@ Identity UX should allow user to choose what token it wants to use as gas price.
 
 ### Requirements & Dependancies
 
-Idea [#145](https://github.com/status-im/ideas/pull/145) is important to seamless and safe integration of gas abstraction for any type of call.
+Idea [145-identity](https://github.com/status-im/ideas/pull/145) is important to seamless and safe integration of gas abstraction for any type of call.
 Implemention of [EIP#191](https://github.com/ethereum/EIPs/issues/191) is somewhat important, specially for making signature verification slightly gas cheaper.
 
 ### Minimum Viable Product
@@ -73,6 +74,7 @@ Description:
 - Moving SNT to other address from SNTController terms (paying gas in SNT)
 
 #### UX Integration
+
 Goal Date: 2018-05-15
 Description:
 - User can create Identity paying in SNT.

--- a/ideas/073-gas-abstraction.md
+++ b/ideas/073-gas-abstraction.md
@@ -13,10 +13,12 @@ Users would sign a message request to contracts which will use user's balance of
 
 ## Swarm Participants
 
-- Lead Contributor:  @3esmit
-- UX: @alexvandesande 
+- Lead Contributor: @3esmit
+- Contributor: @richard-ramos 
+- UX (Mist): @alexvandesande 
+- UX (Status): 
 - Contributor/Testing: @iurimatias 
-- Contributor/Testing: @richard-ramos 
+
 
 ## Product Overview
 
@@ -40,6 +42,8 @@ Important for gas abstraction.
 SNT Controller Gas Relay adaptor: include terms for accepting ethereum signed messages to IdentityGasRelay facotory and for moving the tokens from there using SNT.
 Important for accounts that never held ether, just SNT.
 
+Identity UX should allow user to choose what token it wants to use as gas price.
+
 ### Requirements & Dependancies
 
 Idea [#145](https://github.com/status-im/ideas/pull/145) is important to seamless and safe integration of gas abstraction for any type of call.
@@ -47,26 +51,32 @@ Implemention of [EIP#191](https://github.com/ethereum/EIPs/issues/191) is somewh
 
 ### Minimum Viable Product
 
-Goal Date:
+Goal Date: 2018-05-15
 Description:
-- Users can call EVM by paying gas in a selected token.
-- Users can join gas abstraction by SNTController terms
-- Users can earn tokens by including other's messages
+- Users can use Identity paying gasPrice in any token.
+- Users can create Identity using SNTController and paying with SNT.
+- Users can earn tokens running a node that include other's messages
 
 #### Identity Gas Relay
 
-Goal Date:
+Goal Date: 2018-04-20
 Description: 
 - Gas Relay Node that recieve whisper messages from Identity owners, 
 - Identity User Interface with Gas Relayed option of calls
 
 #### SNT Gas Relayer
 
-Goal Date:
+Goal Date: 2018-04-27
 Description: 
 - Gas Relay Node implements watching messages for SNTController 
 - User interface for creating Identity+ENS register (pay gas in SNT)
 - Moving SNT to other address from SNTController terms (paying gas in SNT)
+
+#### UX Integration
+Goal Date: 2018-05-15
+Description:
+- User can create Identity paying in SNT.
+- User can select differnt tokens in gasPrice when using Identity.
 
 ## Success Metrics
 

--- a/ideas/150-gas-abstraction.md
+++ b/ideas/150-gas-abstraction.md
@@ -2,11 +2,12 @@
 
 ## Preamble
 
-    Idea: 073-gas-abstraction
+    Idea: 150-gas-abstraction
     Title: Gas Abstraction
     Status: In Progress
     Created: 2018-02-01
     Requires: 145-identity
+    Replaces: 073-snt-as-gas
 
 ## Summary
 

--- a/ideas/150-gas-abstraction.md
+++ b/ideas/150-gas-abstraction.md
@@ -4,7 +4,7 @@
 
     Idea: 150-gas-abstraction
     Title: Gas Abstraction
-    Status: In Progress
+    Status: Draft
     Created: 2018-02-01
     Requires: 145-identity
     Replaces: 073-economic-abstraction

--- a/ideas/150-gas-abstraction.md
+++ b/ideas/150-gas-abstraction.md
@@ -16,11 +16,12 @@ Users would sign a message request to contracts which will use user's balance of
 
 ## Swarm Participants
 
-- Lead Contributor: @3esmit
-- Contributor: @richard-ramos 
-- UX (Mist): @alexvandesande 
+- Lead Contributor: Ricardo Guilherme Schmidt
+- Contributor: Richard Ramos
+- Contributor: Iuri Matias
+- UX (Mist): Alexandre Van de Sande 
 - UX (Status): 
-- Contributor/Testing: @iurimatias 
+
 
 ## Product Overview
 

--- a/ideas/150-gas-abstraction.md
+++ b/ideas/150-gas-abstraction.md
@@ -12,7 +12,7 @@
 ## Summary
 
 Enable Status users to pay gas fee with any token that is valueable to society. 
-Users would sign a message request to contracts which will use user's balance of selected token to refund proportional used gas to a incentivezed ETH owner to include that message in a transction.p
+Users would sign a message request to contracts which will use user's Identity balance of selected token to refund proportional used gas to a incentivezed ETH owner to include that message in a transction.p
 
 ## Swarm Participants
 

--- a/ideas/150-gas-abstraction.md
+++ b/ideas/150-gas-abstraction.md
@@ -12,7 +12,7 @@
 ## Summary
 
 Enable Status users to pay gas fee with any token that is valueable to society. 
-Users would sign a message request to contracts which will use user's Identity balance of selected token to refund proportional used gas to a incentivezed ETH owner to include that message in a transction.p
+Users would sign a message request to contracts which will use user's Identity balance of selected token to refund proportional used gas to a incentivezed ETH owner to include that message in a transction.
 
 ## Swarm Participants
 

--- a/ideas/150-gas-abstraction.md
+++ b/ideas/150-gas-abstraction.md
@@ -7,7 +7,7 @@
     Status: In Progress
     Created: 2018-02-01
     Requires: 145-identity
-    Replaces: 073-snt-as-gas
+    Replaces: 073-economic-abstraction
 
 ## Summary
 
@@ -20,7 +20,7 @@ Users would sign a message request to contracts which will use user's Identity b
 - Contributor: Richard Ramos
 - Contributor: Iuri Matias
 - UX (Mist): Alexandre Van de Sande 
-- UX (Status): 
+- UX (Status): (help needed)
 
 
 ## Product Overview
@@ -36,21 +36,25 @@ The product solve this by emulating a gas abstraction by adding "Gas Relayer Act
 
 ### Product Description
 
-Gas Relay node: Status Destkop extension or an independent node can include messages by making automatic transactions calls to smart contracts to earn tokens being offered as gas price refund.
-Fundamental pivot. 
+Gas Relay node: 
+- Status Destkop extension or an independent node can include messages by making automatic transactions calls to smart contracts to earn tokens being offered as gas price refund.
+- Configuration for tokens accepted and types of contract willing to interact with.
+Important as fundamental pivot actor. 
 
-Identity Gas Relay adaptor: include terms for accepting ethereum signed messages representing authorization to call by/for Identity owner offering a gas price refund.
-Important for gas abstraction.
+Identity Gas Relay adaptor: 
+- include smart contract terms for accepting ethereum signed messages representing authorization to call by/for Identity owner offering a gas price refund for relayer.
+- Identity UI should allow user to choose what token it wants to use as gas price.
+Important for gas abstraction of call. 
 
-SNT Controller Gas Relay adaptor: include terms for accepting ethereum signed messages to IdentityGasRelay facotory and for moving the tokens from there using SNT.
-Important for accounts that never held ether, just SNT.
+SNTController Gas Relay adaptor: 
+- include smart contract terms for accepting ethereum signed messages to call `IdentityGasRelayFactory` and for moving the tokens from there using SNT controller contract.
+- a "wizard" UI would make the calls to create a Identity and send user SNT to Identity (so it can be used as ether gas).
+Important for opt-in gas abstraction without ever holding ether.
 
-Identity UX should allow user to choose what token it wants to use as gas price.
 
 ### Requirements & Dependancies
 
-Idea [145-identity](https://github.com/status-im/ideas/pull/145) is important to seamless and safe integration of gas abstraction for any type of call.
-Implemention of [EIP#191](https://github.com/ethereum/EIPs/issues/191) is somewhat important, specially for making signature verification slightly gas cheaper.
+Idea [145-identity](https://github.com/status-im/ideas/pull/145) is important to seamless and safe integration of gas abstraction for any type of call, so identity can become `msg.sender` for other contracts.
 
 ### Minimum Viable Product
 
@@ -60,7 +64,8 @@ Description:
 - Users can create Identity using SNTController and paying with SNT.
 - Users can earn tokens running a node that include other's messages
 
-#### Identity Gas Relay
+#### Identity Gas RelayIdentity UX should allow user to choose what token it wants to use as gas price.
+
 
 Goal Date: 2018-04-20
 Description: 
@@ -72,7 +77,7 @@ Description:
 Goal Date: 2018-04-27
 Description: 
 - Gas Relay Node implements watching messages for SNTController 
-- User interface for creating Identity+ENS register (pay gas in SNT)
+- User interface for creating Identity (pay gas in SNT)
 - Moving SNT to other address from SNTController terms (paying gas in SNT)
 
 #### UX Integration


### PR DESCRIPTION
Replaces #73 
Requires #145
# Gas Abstraction

## Preamble

    Idea: 150-gas-abstraction
    Title: Gas Abstraction
    Status: Draft
    Created: 2018-02-01
    Requires: 145-identity
    Replaces: 073-snt-as-gas

## Summary

Enable Status users to pay gas fee with any token that is valueable to society. 
Users would sign a message request to contracts which will use user's Identity balance of selected token to refund proportional used gas to a incentivezed ETH owner to include that message in a transction.p

## Swarm Participants

- Lead Contributor: @3esmit
- Contributor: @richard-ramos 
- UX (Mist): @alexvandesande 
- UX (Status): 
- Clojure:
- Contributor/Testing: @iurimatias 
