### PR TITLE
KISS iteration update: - old in progress -> limbo; old limbo -> aborted

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Then submit a Pull Request in this repository.
 Ideas looking for people
 
 
-| Idea | Looking for | Swarm lead | In progress? | OKR prios            |
-|------|-------------|------------|--------------|----------------------|
-| #58  | Clojure dev | Adam       | Yes          | p1: p0               |
-| #145 | PM          | Ricardo | No        |                   |
-| #145 | UX          |  Ricardo  | No     |                   |
-| #151 | Clojure dev | Ricardo   | No        | p2: p0          |
+| Idea | Looking for | Swarm lead | In progress? | OKR prios |
+|------|-------------|------------|--------------|-----------|
+| #58  | Clojure dev | Adam       | Yes          | p1: p0    |
+| #145 | PM          | Ricardo    | No           |           |
+| #145 | UX          | Ricardo    | No           |           |
+| #151 | Clojure dev | Ricardo    | No           | p2: p0    |
 
 
 ## Idea Registry
@@ -30,49 +30,49 @@ aborted.
 
 ## In Progress :walking_man:
 
-| Idea                                                                | State                     | Success metrics?       | Exit criteria?         | Clear roles?           | Future iteration?                 |
-|---------------------------------------------------------------------|---------------------------|------------------------|------------------------|------------------------|-----------------------------------|
-| [127-sob-testing](ideas/127-SOB-testing-process.md)  | :walking_man: In Progress | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes            |
-| [120-swarm-process](ideas/120-swarm-process.md)                     | :walking_man: In Progress | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes            |
-| [121-swarm-compensation](ideas/121-swarm-compensation/)     | :walking_man: In Progress     | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes                                 |
-| [92-disc-v5-research](ideas/92-disc-v5-research.md)                 | :walking_man: In Progress | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes            |
-| [87-new-protocol](ideas/87-new-protocol.md)                         | :walking_man: In Progress | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes            |
-| [83-energy-efficient](ideas/83-energy-efficient.md)                 | :walking_man: In Progress | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes            |
-| [80-onboarding](ideas/80-onboarding.md)                             | :walking_man: In Progress | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes            |
-| [68-core-metrics](ideas/68-core-metrics.md)                         | :walking_man: In Progress | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes            |
-| [63-refactor-geth-packages](ideas/63-refactor-geth-packages.md)     | :walking_man: In Progress | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes            |
-| [58-mainnet](ideas/58-mainnet.md) | :walking_man: In Progress    | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes |
-| [34-react-native-qt](ideas/34-react-native-qt.md)                   | :walking_man: In Progress | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes            |
-| [140-sob-improve-onboarding](ideas/140-sob-improve-onboarding/)     | :walking_man: In Progress     | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes                                 |
-| [122-sob-metrics](ideas/122-sob-metrics.md)     | :walking_man: In Progress     | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes                                 |
-| [154-support-web3.js-library](ideas/154-support-web3.js-library.md)      | :walking_man: In Progress    | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes                 | :white_check_mark: Yes |
+| Idea                                                                | State                     | Success metrics?       | Exit criteria?         | Clear roles?           | Future iteration?      |
+|---------------------------------------------------------------------|---------------------------|------------------------|------------------------|------------------------|------------------------|
+| [127-sob-testing](ideas/127-SOB-testing-process.md)                 | :walking_man: In Progress | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes |
+| [120-swarm-process](ideas/120-swarm-process.md)                     | :walking_man: In Progress | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes |
+| [121-swarm-compensation](ideas/121-swarm-compensation/)             | :walking_man: In Progress | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes |
+| [92-disc-v5-research](ideas/92-disc-v5-research.md)                 | :walking_man: In Progress | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes |
+| [87-new-protocol](ideas/87-new-protocol.md)                         | :walking_man: In Progress | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes |
+| [83-energy-efficient](ideas/83-energy-efficient.md)                 | :walking_man: In Progress | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes |
+| [80-onboarding](ideas/80-onboarding.md)                             | :walking_man: In Progress | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes |
+| [68-core-metrics](ideas/68-core-metrics.md)                         | :walking_man: In Progress | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes |
+| [63-refactor-geth-packages](ideas/63-refactor-geth-packages.md)     | :walking_man: In Progress | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes |
+| [58-mainnet](ideas/58-mainnet.md)                                   | :walking_man: In Progress | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes |
+| [34-react-native-qt](ideas/34-react-native-qt.md)                   | :walking_man: In Progress | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes |
+| [140-sob-improve-onboarding](ideas/140-sob-improve-onboarding/)     | :walking_man: In Progress | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes |
+| [122-sob-metrics](ideas/122-sob-metrics.md)                         | :walking_man: In Progress | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes |
+| [154-support-web3.js-library](ideas/154-support-web3.js-library.md) | :walking_man: In Progress | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes |
 
 ## Draft :seedling: and limbo :question:
-| Idea                                                                | State                     | Success metrics?       | Exit criteria?         | Clear roles?           | Future iteration?                 |
-|---------------------------------------------------------------------|---------------------------|------------------------|------------------------|------------------------|-----------------------------------|
-| [150-gas-abstraction](ideas/150-gas-abstraction.md) | :seedling: Draft | :white_check_mark: Yes | :x: No | :x: No | - :white_check_mark: Yes |
-| [027-username-ens-subdomain](ideas/027-username-ens-subdomain.md)        | :seedling: Draft     | :x: No | :white_check_mark: Yes  | :x: No | - :white_check_mark: Yes |
-| [145-identity](ideas/145-identity.md) | :seedling: Draft | :x: No                 | :white_check_mark: Yes | :x: No | - :white_check_mark: Yes |
-| [94-wallet-compatibility](ideas/94-wallet-compatibility.md)       | :seedling: Draft | :x: No                 | :white_check_mark: Yes | :white_check_mark: Yes | - :x: No               |
-| [134-seamless-login](ideas/134-seamless-login.md)               | :seedling: Draft          | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes                 | :white_check_mark: Yes         |
-| [117-message-ordering](ideas/117-message-ordering.md)               | :seedling: Draft          | :white_check_mark: Yes | :white_check_mark: Yes | :x: No                  | :x: No         |
-| [99-confidence](ideas/99-confidence.md)                             | :seedling: Draft          | :x: no                 | :x: no                 | :x: no                 | :x: no                            |
-| [95-les-service-model](ideas/095-les-service-model/)                | :seedling: Draft          | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes             | :x: no                            |
-| [86-push-notif-v2](ideas/86-push-notif-v2.md)                       | :seedling: Draft          | :x: no                 | :x: no                 | :x: no                 | :x: no                            |
-| [146-status-go-sdk](ideas/146-status-go-sdk/)              | :seedling: Draft          | :white_check_mark: yes                 | :white_check_mark: yes                 | :x: no                 | :x: no                            |
-| [76-smooth-ui](ideas/smooth-ui.md)                                  | :question: Limbo          | :white_check_mark: Yes | :x: No                 | :x: No                 | :white_check_mark: Yes :question: |
-| [71-low-traffic](ideas/71-low-traffic.md)                           | :question: Limbo          | :white_check_mark: Yes | :x: No                 | :x: No                 | :white_check_mark: Yes :question: |
-| [101-extensions](ideas/101-extensions)      | :seedling: Draft    | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | -                      |
-| [142-recovery-compatibility](ideas/142-recovery-compatibility)      | :seedling: Draft    | :white_check_mark: Yes | :white_check_mark: Yes | :x: No                 | -                      |
+| Idea                                                              | State            | Success metrics?       | Exit criteria?         | Clear roles?           | Future iteration?        |
+|-------------------------------------------------------------------|------------------|------------------------|------------------------|------------------------|--------------------------|
+| [150-gas-abstraction](ideas/150-gas-abstraction.md)               | :seedling: Draft | :white_check_mark: Yes | :x: No                 | :x: No                 | - :white_check_mark: Yes |
+| [027-username-ens-subdomain](ideas/027-username-ens-subdomain.md) | :seedling: Draft | :x: No                 | :white_check_mark: Yes | :x: No                 | - :white_check_mark: Yes |
+| [145-identity](ideas/145-identity.md)                             | :seedling: Draft | :x: No                 | :white_check_mark: Yes | :x: No                 | - :white_check_mark: Yes |
+| [94-wallet-compatibility](ideas/94-wallet-compatibility.md)       | :seedling: Draft | :x: No                 | :white_check_mark: Yes | :white_check_mark: Yes | - :x: No                 |
+| [134-seamless-login](ideas/134-seamless-login.md)                 | :seedling: Draft | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes   |
+| [117-message-ordering](ideas/117-message-ordering.md)             | :seedling: Draft | :white_check_mark: Yes | :white_check_mark: Yes | :x: No                 | :x: No                   |
+| [99-confidence](ideas/99-confidence.md)                           | :seedling: Draft | :x: no                 | :x: no                 | :x: no                 | :x: no                   |
+| [95-les-service-model](ideas/095-les-service-model/)              | :seedling: Draft | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :x: no                   |
+| [86-push-notif-v2](ideas/86-push-notif-v2.md)                     | :seedling: Draft | :x: no                 | :x: no                 | :x: no                 | :x: no                   |
+| [146-status-go-sdk](ideas/146-status-go-sdk/)                     | :seedling: Draft | :white_check_mark: yes | :white_check_mark: yes | :x: no                 | :x: no                   |
+| [101-extensions](ideas/101-extensions)                            | :seedling: Draft | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | -                        |
+| [142-recovery-compatibility](ideas/142-recovery-compatibility)    | :seedling: Draft | :white_check_mark: Yes | :white_check_mark: Yes | :x: No                 | -                        |
 
 ## Completed :champagne: and aborted :dagger:
 
-| Idea                                                                | State                     | Success metrics?       | Exit criteria?         | Clear roles?           | Future iteration?                 |
-|---------------------------------------------------------------------|---------------------------|------------------------|------------------------|------------------------|-----------------------------------|
-| [64-release](ideas/64-release.md)                                   | :dagger: Aborted          | :white_check_mark: Yes | :x: No                 | :white_check_mark: Yes | -                                 |
-| [61-app-structure-refinement](ideas/61-app-structure-refinement.md) | :champagne: Completed     | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | -                                 |
-| [3-erc20-token-support](ideas/3-erc20-token-support.md)             | :champagne: Completed     | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | -                                 |
-| [1-offline-inboxing](ideas/1-offline-inboxing.md)                   | :champagne: Completed     | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | -                                 |
+| Idea                                                                | State                 | Success metrics?       | Exit criteria?         | Clear roles?           | Future iteration?  |
+|---------------------------------------------------------------------|-----------------------|------------------------|------------------------|------------------------|--------------------|
+| [76-smooth-ui](ideas/smooth-ui.md)                                  | :dagger: aborted      | :white_check_mark: Yes | :x: No                 | :x: No                 | :white_check_mark: |
+| [71-low-traffic](ideas/71-low-traffic.md)                           | :dagger: aborted      | :white_check_mark: Yes | :x: No                 | :x: No                 | :white_check_mark: |
+| [64-release](ideas/64-release.md)                                   | :dagger: Aborted      | :white_check_mark: Yes | :x: No                 | :white_check_mark: Yes | -                  |
+| [61-app-structure-refinement](ideas/61-app-structure-refinement.md) | :champagne: Completed | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | -                  |
+| [3-erc20-token-support](ideas/3-erc20-token-support.md)             | :champagne: Completed | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | -                  |
+| [1-offline-inboxing](ideas/1-offline-inboxing.md)                   | :champagne: Completed | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | -                  |
 
 ## Commitment Registry
 

--- a/ideas/71-low-traffic.md
+++ b/ideas/71-low-traffic.md
@@ -1,7 +1,7 @@
 ## Preamble
-    Idea: <to be assigned>
+    Idea: 71-low-traffic
     Title: Low traffic consumption(technical)
-    Status: Limbo
+    Status: Aborted
     Created: 2018-01-25
 
 ## Summary

--- a/ideas/76-smooth-ui.md
+++ b/ideas/76-smooth-ui.md
@@ -5,7 +5,7 @@
 
     Idea: 76-smooth-ui
     Title: Make UI fast and smooth
-    Status: Limbo
+    Status: Aborted
     Created: 2018-01-24
     Requires (*optional): 87-new-protocol
 


### PR DESCRIPTION
As discussed earlier, we mark all swarms as in limbo per default each iteration, as well as old limbo to aborted. This is the default action, see https://github.com/status-im/ideas/blob/master/MANUAL.md#swarm-lifecycle

Most of these are probably still in progress, but it'd be good to get swarm lead confirmation. This is also a good opportunity to check that idea is up to date w.r.t. contributors and iterations (future and copy-paste town hall, e.g.) etc.

To confirm idea is still in progress and that idea is up to date, just reply "swarm XXX is still in progress", with optional link to PR if adjustments are needed.

In Progress -> Limbo:
- [x] 120-swarm-process
- [x] 121-swarm-compensation
- [x] 92-disc-v5-research
- [x] 87-new-protocol
- [x] 83-energy-efficient
- [x] 80-onboarding
- [x] 68-core-metrics
- [x] 63-refactor-geth-packages
- [x] 58-mainnet
- [x] 34-react-native-qt
- [x] 140-sob-improve-onboarding
- [x] 122-sob-metrics

Limbo -> Aborted:
- [x] 76-smooth-ui
- [ ] 71-low-traffic

---

- [ ] TODO: for swarms real limbo/aborted, update ideas themselves, not just README, also commitment registry