### PR TITLE
Revert "134 seamless login is in progress"

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ aborted.
 | [140-sob-improve-onboarding](ideas/140-sob-improve-onboarding/)     | :walking_man: In Progress     | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes                                 |
 | [122-sob-metrics](ideas/122-sob-metrics.md)     | :walking_man: In Progress     | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes                                 |
 | [154-support-web3.js-library](ideas/154-support-web3.js-library.md)      | :walking_man: In Progress    | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes                 | :white_check_mark: Yes |
-| [134-seamless-login](ideas/134-seamless-login.md)               | :walking_man: In Progress         | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes                 | :white_check_mark: Yes         |
 
 ## Draft :seedling: and limbo :question:
 | Idea                                                                | State                     | Success metrics?       | Exit criteria?         | Clear roles?           | Future iteration?                 |
 |---------------------------------------------------------------------|---------------------------|------------------------|------------------------|------------------------|-----------------------------------|
+| [134-seamless-login](ideas/134-seamless-login.md)               | :seedling: Draft          | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes                 | :white_check_mark: Yes         |
 | [117-message-ordering](ideas/117-message-ordering.md)               | :seedling: Draft          | :white_check_mark: Yes | :white_check_mark: Yes | :x: No                  | :x: No         |
 | [99-confidence](ideas/99-confidence.md)                             | :seedling: Draft          | :x: no                 | :x: no                 | :x: no                 | :x: no                            |
 | [95-les-service-model](ideas/095-les-service-model/)                | :seedling: Draft          | :white_check_mark: Yes | :white_check_mark: Yes | :white_check_mark: Yes             | :x: no                            |

--- a/ideas/134-seamless-login.md
+++ b/ideas/134-seamless-login.md
@@ -2,7 +2,7 @@
 
     Idea: 132
     Title: Seamless Login
-    Status: In Progress
+    Status: Draft
     Created: 2018-05-04
 
 


### PR DESCRIPTION
This reverts commit a2b3608711ac1cfa4e91f1c04c7a4add85d77967.

Reverting for two reasons:

1) It didn't actually go through any kind of review when going from unfinished draft to in progress, despite concerns being raised in initial review
2) Security concern isn't taken seriously, this is a pre-requisite in even working on this idea at all. At the very least the idea should present the trade-offs that are being made wrt security.