### PR TITLE
fixed formatting for idea 170 metadata

### DIFF
--- a/ideas/170-wallet-improvements.md
+++ b/ideas/170-wallet-improvements.md
@@ -1,4 +1,3 @@
-
 ---
 id: 170-wallet-improvements
 title: Wallet Improvements


### PR DESCRIPTION
Metadata are not parsed right if there is an empty line before the snippet. 