### PR TITLE
Add ideas 300 to 306, corresponding to teams active

### DIFF
--- a/ideas/300-core-infra.md
+++ b/ideas/300-core-infra.md
@@ -1,0 +1,24 @@
+---
+id: 300-core-infra
+title: Core Infra Team
+status: Active
+created: 2018-05-01
+category: core
+lead-contributor: jakubgs
+contributors:
+    - jakubgs
+    - adambabik
+    - corey
+exit-criteria: no
+success-metrics: no
+clear-roles: yes
+future-iterations: no
+roles-needed:
+---
+
+This should probably be filled out similar to Ideas template, but this will do as a skeleton.
+
+The Core Infra team is an infrastructure team that supports and enables other
+client teams (mobile, desktop) as well as product teams (chat, wallet, dapp). It is a sibling to the p2p team.
+
+Current state of it is: ...

--- a/ideas/301-core-p2p.md
+++ b/ideas/301-core-p2p.md
@@ -1,0 +1,25 @@
+---
+id: 301-core-p2p-team
+title: Core P2P Team
+status: Active
+created: 2018-05-01
+category: core
+lead-contributor: adambabik
+contributors:
+    - adambabik
+    - dshulyak
+    - divan
+exit-criteria: no
+success-metrics: no
+clear-roles: yes
+future-iterations: no
+roles-needed:
+---
+
+This should probably be filled out similar to Ideas template, but this will do as a skeleton.
+
+The P2P team is an infrastructure team that is focused on the P2P layer of Status. It supports and enables client teams such as mobile app and desktop app, as well as product teams such as chat, dapps and wallet.
+
+They currently share chat home with core-infra.
+
+Current state of it is: ...

--- a/ideas/302-core-mobile-app.md
+++ b/ideas/302-core-mobile-app.md
@@ -1,0 +1,27 @@
+---
+id: 302-core-mobile-app-team
+title: Core Mobile App Team
+status: Active
+created: 2018-05-01
+category: core
+lead-contributor: mandrigin
+contributors:
+    - chadyj
+    - mandrigin
+    - rasom
+    - alwx
+    - janherich
+exit-criteria: no
+success-metrics: no
+clear-roles: yes
+future-iterations: no
+roles-needed:
+---
+
+This should probably be filled out similar to Ideas template, but this will do as a skeleton.
+
+The Mobile App team is a client team that is focused on the mobile app client of
+Status. It gets support and is enabled by the Infra and P2P team, and it
+supports product teams Chat, Dapp, and Wallet.
+
+Current state of it is regular releases, as well as ...

--- a/ideas/303-core-desktop.md
+++ b/ideas/303-core-desktop.md
@@ -1,0 +1,25 @@
+---
+id: 303-core-desktop
+title: Core Desktop Team
+status: Active
+created: 2018-05-01
+category: core
+lead-contributor: vitaliy
+contributors:
+    - chadyj
+    - vitaliy
+    - maxris
+    - volodymyr
+    - gnl
+exit-criteria: no
+success-metrics: no
+clear-roles: yes
+future-iterations: no
+roles-needed:
+---
+
+This should probably be filled out similar to Ideas template, but this will do as a skeleton.
+
+The Core Desktop team is a client team that is focused on the Desktop client of Status. It gets support and is enabled by the Infra and P2P team, and it supports the product teams chat, wallet, and dapps.
+
+Current state of it is focused on getting everyone to use Status everyday at their desktop.

--- a/ideas/304-core-chat.md
+++ b/ideas/304-core-chat.md
@@ -1,0 +1,30 @@
+---
+id: 304-core-chat
+title: Core Chat Team
+status: Active
+created: 2018-05-01
+category: core
+lead-contributor: pedro
+contributors:
+    - pedro
+    - chadyj
+    - yenda
+    - dmitryn
+    - cammellos
+exit-criteria: no
+success-metrics: no
+clear-roles: yes
+future-iterations: no
+roles-needed:
+---
+
+This should probably be filled out similar to Ideas template, but this will do
+as a skeleton.
+
+The Core Chat team is a product team that is focused on the chat experience of
+Status. It gets support and is enabled by the Mobile App team as well as Infra and P2P team.
+
+Current state of it is focused on [PFS swarm](289-perfect-forward-secrecy), as well as minor UX improvements and so on. Recently it has started focusing on the Chat experience of Desktop as well.
+
+
+

--- a/ideas/305-core-wallet-account.md
+++ b/ideas/305-core-wallet-account.md
@@ -1,0 +1,22 @@
+---
+id: 305-core-wallet
+title: Core Wallet and Account Team
+status: Active
+created: 2018-05-01
+category: core
+lead-contributor: goranjovic
+contributors:
+    - chadyj
+    - goranjovic
+exit-criteria: no
+success-metrics: no
+clear-roles: yes
+future-iterations: no
+roles-needed:
+---
+
+This should probably be filled out similar to Ideas template, but this will do as a skeleton.
+
+The Core Wallet and Account team is a product team that is focused on the wallet and account experience of Status. It gets support and is enabled by the Mobile App team as well as Infra and P2P team.
+
+Current state of it is: ....

--- a/ideas/306-core-dapp-developers.md
+++ b/ideas/306-core-dapp-developers.md
@@ -1,0 +1,24 @@
+---
+id: 306-core-dapp-team
+title: Core Dapp Team
+status: Active
+created: 2018-05-01
+category: core
+lead-contributor: jeluard
+contributors:
+    - jeluard
+    - flexsurfer
+    - rachelhamlin
+    - alwx
+exit-criteria: no
+success-metrics: no
+clear-roles: yes
+future-iterations: no
+roles-needed:
+---
+
+This should probably be filled out similar to Ideas template, but this will do as a skeleton.
+
+The Core Dapp and Developer team is a product team that is focused on the dapp and developer experience of Status. It gets support and is enabled by the Mobile App team as well as Infra and P2P team.
+
+Current state of it is focused on: Extensions as well as...


### PR DESCRIPTION
Updates teams with rough skeleton descriptions and contributors so we can have a clearer view of https://ideas.status.im/people and https://ideas.status.im/all

Addresses https://github.com/status-im/ideas/issues/305

Please look over your teams and see what changes you want to make. Can also do changes in separate PR if this seems more appropriate

<blockquote><div>Status - Ideas</div><div><strong><a href="http://ideas.status.im/people">People</a></strong></div><div>Swarm Home. New, completed and in-progress features for Status.</div></blockquote>
<blockquote><div>Status - Ideas</div><div><strong><a href="http://ideas.status.im/all">Ideas</a></strong></div><div>Swarm Home. New, completed and in-progress features for Status.</div></blockquote>

The idea is also to get a better understanding of headcount and what each team is focusing on.